### PR TITLE
demote to java 17, since helpmojo plugin does not support java 18+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ runtime/Cpp/runtime/libantlr4-runtime.dylib
 
 # Go test and performance trace files
 **/*.pprof
+runtime-testsuite/gen
+tool-testsuite/gen

--- a/antlr5-maven-plugin/pom.xml
+++ b/antlr5-maven-plugin/pom.xml
@@ -159,7 +159,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-                <release>8</release>
+                <release>17</release>
+                <source>17</source>
+                <target>17</target>
             </configuration>
         </plugin>
     </plugins>

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 		    <groupId>org.openjdk.jol</groupId>
 		    <artifactId>jol-core</artifactId>
-		    <version>0.17</version>
+		    <version>0.16</version>
 		</dependency>
 	</dependencies>
 

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 		    <groupId>org.openjdk.jol</groupId>
 		    <artifactId>jol-core</artifactId>
-		    <version>0.16</version>
+		    <version>0.17</version>
 		</dependency>
 	</dependencies>
 
@@ -116,9 +116,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>21</release>
-                    <source>21</source>
-                    <target>21</target>
+                    <release>17</release>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/perf/TimeLexerSpeed.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/perf/TimeLexerSpeed.java
@@ -166,8 +166,8 @@ Warming up Java compiler....
  *  @since 4.7
  */
 public class TimeLexerSpeed { // don't call it Test else it'll run during "mvn test"
-	public static final String Parser_java_file = "Java/src/org/antlr/v4/runtime/Parser.java";
-	public static final String RuleContext_java_file = "Java/src/org/antlr/v4/runtime/RuleContext.java";
+	public static final String Parser_java_file = "Java/src/org/antlr/v5/runtime/Parser.java";
+	public static final String RuleContext_java_file = "Java/src/org/antlr/v5/runtime/RuleContext.java";
 	public static final String PerfDir = "org/antlr/v5/test/runtime/java/api/perf";
 
 	public boolean output = true;

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -111,9 +111,9 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-                    <release>21</release>
-					<source>21</source>
-					<target>21</target>
+                    <release>17</release>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -207,8 +207,8 @@
 							<target>${basedir}/target/generated-sources/tool/src/org/antlr/v5/unicode/UnicodeData.java</target>
 							<controller>
 								<className>org.antlr.v5.unicode.UnicodeDataTemplateController</className>
-								<sourceVersion>21</sourceVersion>
-								<targetVersion>21</targetVersion>
+								<sourceVersion>17</sourceVersion>
+								<targetVersion>17</targetVersion>
 								<method>getProperties</method>
 							</controller>
 						</template>


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
