### PR TITLE
Updating README to refer to ANTLR 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,12 @@ You can buy the book [The Definitive ANTLR 4 Reference](http://amzn.com/19343569
 
 You will find the [Book source code](http://pragprog.com/titles/tpantlr2/source_code) useful.
 
-## Additional grammars (for ANTLR 4)
-[This repository](https://github.com/antlr/grammars-v4) is a collection of grammars without actions where the
+## Additional grammars
+
+As of now, there is no collection of grammars for ANTLR 5, but we plan
+to grow such collection in [grammars-v5](https://github.com/antlr/grammars-v5), which is currently empty.
+
+Until we get grammars for ANTLR 5, you can take a look at [this repository](https://github.com/antlr/grammars-v4); it is a collection of grammars for ANTLR 4 without actions where the
 root directory name is the all-lowercase name of the language parsed
 by the grammar. For example, java, cpp, csharp, c, etc...
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,5 @@ You will find the [Book source code](http://pragprog.com/titles/tpantlr2/source_
 As of now, there is no collection of grammars for ANTLR 5, but we plan
 to grow such collection in [grammars-v5](https://github.com/antlr/grammars-v5), which is currently empty.
 
-Until we get grammars for ANTLR 5, you can take a look at [this repository](https://github.com/antlr/grammars-v4); it is a collection of grammars for ANTLR 4 without actions where the
-root directory name is the all-lowercase name of the language parsed
+Until we get grammars for ANTLR 5, you can take a look at [this repository](https://github.com/antlr/grammars-v4); it is a collection of grammars for ANTLR 4 where the root directory name is the all-lowercase name of the language parsed
 by the grammar. For example, java, cpp, csharp, c, etc...
-
-Note that these grammars are written for ANTLR 4. As of now, the equivalent [list of grammars for ANTLR 5](https://github.com/antlr/grammars-v5) is empty.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 **ANTLR** (ANother Tool for Language Recognition) is a powerful parser generator for reading, processing, executing, or translating structured text or binary files. It's widely used to build languages, tools, and frameworks. From a grammar, ANTLR generates a parser that can build parse trees and also generates a listener interface (or visitor) that makes it easy to respond to the recognition of phrases of interest.
 
+_This is a new version of ANTLR, in an early development stage_. _If you are looking for a production ready version look into [ANTLR v4](https://github.com/antlr/antlr4)_.
+
 **Dev branch build status**
 
 [![MacOSX, Windows, Linux](https://github.com/antlr/antlr5/actions/workflows/hosted.yml/badge.svg)](https://github.com/antlr/antlr5/actions/workflows/hosted.yml) (github actions)
@@ -21,7 +23,7 @@ As other platforms provide support for recent WebAssembly features, such as garb
 
 ## Repo branch structure
 
-The default branch for this repo is [`main`](https://github.com/antlr/antlr5/tree/main), which is the latest stable release and has tags for the various releases.  Branch [`dev`](https://github.com/antlr/antlr5/tree/dev) is where development occurs between releases and all pull requests should be derived from that branch. The `dev` branch is merged back into `main` to cut a release and the release state is tagged (e.g., with `1.0-rc1` or `1.0`.) Visually our process looks roughly like this:
+The default branch for this repo is [`main`](https://github.com/antlr/antlr5/tree/main), which is the latest stable release and has tags for the various releases.  Branch [`dev`](https://github.com/antlr/antlr5/tree/dev) is where development occurs between releases and all pull requests should be derived from that branch. The `dev` branch is merged back into `main` to cut a release and the release state is tagged (e.g., with `5.1-rc1` or `5.1`.) Visually our process looks roughly like this:
 
 <img src="doc/images/new-antlr-branches.png" width="500">
 
@@ -54,14 +56,17 @@ You might also find the following pages useful, particularly if you want to mess
 
 ## The Definitive ANTLR 4 Reference
 
+_Given the fact that work on ANTLR 5 is at a very early stage, there is currently no material about ANTLR 5. However ANTLR 5 is based on the amazing work done in ANTLR 4, and it follows many of the ideas introduced by ANTLR 4. For this reason it makes sense to study the existing material on ANTLR 4._
+
 Programmers run into parsing problems all the time. Whether it’s a data format like JSON, a network protocol like SMTP, a server configuration file for Apache, a PostScript/PDF file, or a simple spreadsheet macro language—ANTLR v4 and this book will demystify the process. ANTLR v4 has been rewritten from scratch to make it easier than ever to build parsers and the language applications built on top. This completely rewritten new edition of the bestselling Definitive ANTLR Reference shows you how to take advantage of these new features.
 
 You can buy the book [The Definitive ANTLR 4 Reference](http://amzn.com/1934356999) at amazon or an [electronic version at the publisher's site](https://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference).
 
 You will find the [Book source code](http://pragprog.com/titles/tpantlr2/source_code) useful.
 
-## Additional grammars
-
-[This repository](https://github.com/antlr/grammars-v5) is a collection of grammars verified with ANTLR 5 where the
+## Additional grammars (for ANTLR 4)
+[This repository](https://github.com/antlr/grammars-v4) is a collection of grammars without actions where the
 root directory name is the all-lowercase name of the language parsed
 by the grammar. For example, java, cpp, csharp, c, etc...
+
+Note that these grammars are written for ANTLR 4. As of now, the equivalent [list of grammars for ANTLR 5](https://github.com/antlr/grammars-v5) is empty.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **ANTLR** (ANother Tool for Language Recognition) is a powerful parser generator for reading, processing, executing, or translating structured text or binary files. It's widely used to build languages, tools, and frameworks. From a grammar, ANTLR generates a parser that can build parse trees and also generates a listener interface (or visitor) that makes it easy to respond to the recognition of phrases of interest.
 
-_This is a new version of ANTLR, in an early development stage_. _If you are looking for a production ready version look into [ANTLR v4](https://github.com/antlr/antlr4)_.
+_This is a new version of ANTLR, in an early development stage_. _If you are looking for a production ready version look into [ANTLR v4](http://antlr4.org/)_.
 
 **Dev branch build status**
 
@@ -66,8 +66,6 @@ You will find the [Book source code](http://pragprog.com/titles/tpantlr2/source_
 
 ## Additional grammars
 
-As of now, there is no collection of grammars for ANTLR 5, but we plan
-to grow such collection in [grammars-v5](https://github.com/antlr/grammars-v5), which is currently empty.
+As of now, there is no collection of grammars for ANTLR 5, but we plan to grow such collection in [grammars-v5](https://github.com/antlr/grammars-v5), which is currently empty.
 
-Until we get grammars for ANTLR 5, you can take a look at [this repository](https://github.com/antlr/grammars-v4); it is a collection of grammars for ANTLR 4 where the root directory name is the all-lowercase name of the language parsed
-by the grammar. For example, java, cpp, csharp, c, etc...
+Until we get grammars for ANTLR 5, you can take a look at [this repository](https://github.com/antlr/grammars-v4); it is a collection of grammars verified for ANTLR 4 where the root directory name is the all-lowercase name of the language parsed by the grammar. For example, java, cpp, csharp, c, etc...


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

I took a first look at the README, renaming most references to ANTLR 4 into references to ANTLR 5.

I also tried to:
* State that this project is experimental, and that most people should look at ANTLR 4
* Summarizing very shortly why ANTLR 5 came to by and pointing out to antlr5-specs for the details
* Remove some links that were very specific to ANTLR 4
* Add a comment about The Definitive ANTLR 4 Reference, in the context of ANTLR 5
* Add a reference to grammars-v5 (while keeping a reference to grammars-v4)

This is related to #3 

Follow up: Update image to change master into main. This would be easier if we had the sources of the image.