### PR TITLE
Update the Copyright

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+Copyright (c) 2012-present The ANTLR Project. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 // Note(Edoardo): JS is single threaded, so a normal list is good enough

--- a/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package com.strumenta.antlrkotlin.runtime
 

--- a/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 import kotlin.contracts.ExperimentalContracts

--- a/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
+++ b/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package com.strumenta.antlrkotlin.runtime
 

--- a/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/org/antlr/v5/kotlinruntime/CharStreams.kt
+++ b/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/org/antlr/v5/kotlinruntime/CharStreams.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 public actual object CharStreams : AbstractCharStreams()

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package com.strumenta.antlrkotlin.runtime
 

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 @file:Suppress("NOTHING_TO_INLINE")
 
 package com.strumenta.antlrkotlin.runtime

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/Environment.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/Environment.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 internal actual fun platformGetEnv(name: String): String? {

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IsNodeJs.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IsNodeJs.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 /**

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package com.strumenta.antlrkotlin.runtime
 

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 @file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
 
 package com.strumenta.antlrkotlin.runtime

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): make thread safe at some point

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Environment.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Environment.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 import kotlinx.cinterop.ExperimentalForeignApi

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package com.strumenta.antlrkotlin.runtime
 

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 import kotlin.contracts.ExperimentalContracts

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package com.strumenta.antlrkotlin.runtime
 

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/org/antlr/v4/kotlinruntime/CharStreams.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/org/antlr/v4/kotlinruntime/CharStreams.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 public actual object CharStreams : AbstractCharStreams()

--- a/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
+++ b/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 public actual typealias BitSet = SimpleBitSet

--- a/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 internal actual fun platformPrintErrLn(): Unit =

--- a/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/Environment.kt
+++ b/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/Environment.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 @Suppress("UNUSED_PARAMETER", "RedundantNullableReturnType")

--- a/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/IsNodeJs.kt
+++ b/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/IsNodeJs.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 /**

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 public actual typealias BitSet = SimpleBitSet

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 @file:Suppress("NOTHING_TO_INLINE", "INVISIBLE_MEMBER")
 
 package com.strumenta.antlrkotlin.runtime

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 // Note(Edoardo): WASI is single threaded at the moment, so a normal list is good enough

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/Environment.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/Environment.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 import kotlin.wasm.WasmImport

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): implement real identity comparison

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 import kotlin.contracts.ExperimentalContracts

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): implement real weak keys

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/org/antlr/v4/kotlinruntime/CharStreams.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/org/antlr/v4/kotlinruntime/CharStreams.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 public actual object CharStreams : AbstractCharStreams()

--- a/antlr5-maven-plugin/nb-configuration.xml
+++ b/antlr5-maven-plugin/nb-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/antlr5-maven-plugin/pom.xml
+++ b/antlr5-maven-plugin/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/antlr5-maven-plugin/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/antlr5-maven-plugin/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/antlr5-maven-plugin/src/main/java/org/antlr/mojo/antlr5/Antlr5ErrorLog.java
+++ b/antlr5-maven-plugin/src/main/java/org/antlr/mojo/antlr5/Antlr5ErrorLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/antlr5-maven-plugin/src/main/java/org/antlr/mojo/antlr5/Antlr5Mojo.java
+++ b/antlr5-maven-plugin/src/main/java/org/antlr/mojo/antlr5/Antlr5Mojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/antlr5-maven-plugin/src/main/java/org/antlr/mojo/antlr5/GrammarDependencies.java
+++ b/antlr5-maven-plugin/src/main/java/org/antlr/mojo/antlr5/GrammarDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/antlr5-maven-plugin/src/main/java/org/antlr/mojo/antlr5/MojoUtils.java
+++ b/antlr5-maven-plugin/src/main/java/org/antlr/mojo/antlr5/MojoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/antlr5-maven-plugin/src/site/site.xml
+++ b/antlr5-maven-plugin/src/site/site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/antlr5-maven-plugin/src/test/java/org/antlr/mojo/antlr5/Antlr4MojoTest.java
+++ b/antlr5-maven-plugin/src/test/java/org/antlr/mojo/antlr5/Antlr4MojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/antlr5-maven-plugin/src/test/projects/dependencyRemoved/pom.xml
+++ b/antlr5-maven-plugin/src/test/projects/dependencyRemoved/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/antlr5-maven-plugin/src/test/projects/importTokens/pom.xml
+++ b/antlr5-maven-plugin/src/test/projects/importTokens/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/antlr5-maven-plugin/src/test/projects/importsCustom/pom.xml
+++ b/antlr5-maven-plugin/src/test/projects/importsCustom/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/antlr5-maven-plugin/src/test/projects/importsStandard/pom.xml
+++ b/antlr5-maven-plugin/src/test/projects/importsStandard/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/runtime-testsuite/test/org/antlr/v5/runtime/TestCodePointCharStream.java
+++ b/runtime-testsuite/test/org/antlr/v5/runtime/TestCodePointCharStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/CustomDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/CustomDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/ErrorQueue.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/ErrorQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/FileUtils.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/Generator.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/Generator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/GrammarType.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/GrammarType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/OSType.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/OSType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/Processor.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/Processor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/ProcessorResult.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/ProcessorResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/RunOptions.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/RunOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeRunner.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeTestDescriptor.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeTestDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeTestDescriptorParser.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeTestDescriptorParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeTestUtils.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeTests.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/RuntimeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/Stage.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/Stage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/StreamReader.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/StreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/JavaRunner.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/JavaRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/JavaRuntimeTests.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/JavaRuntimeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/TestCharStreams.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/TestCharStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/TestIntegerList.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/TestIntegerList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/TestInterpreterDataReader.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/TestInterpreterDataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/TestExpectedTokens.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/TestExpectedTokens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/TestTokenStream.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/TestTokenStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/TestTokenStreamRewriter.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/TestTokenStreamRewriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/TestVisitors.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/TestVisitors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/perf/Instrumentor.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/perf/Instrumentor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/perf/TimeLexerSpeed.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/java/api/perf/TimeLexerSpeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/javascript/JavaScriptRuntimeTests.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/javascript/JavaScriptRuntimeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/javascript/NodeRunner.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/javascript/NodeRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/StringTest.kt
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/StringTest.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 import org.junit.jupiter.api.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/com/strumenta/antlrkotlin/runtime/BitSetTest.kt
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/com/strumenta/antlrkotlin/runtime/BitSetTest.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.test.runtime.kotlin.commonTest.com.strumenta.antlrkotlin.runtime
 
 import com.strumenta.antlrkotlin.runtime.BitSet

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/org/antlr/v4/kotlinruntime/CharStreamsTest.kt
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/org/antlr/v4/kotlinruntime/CharStreamsTest.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.test.runtime.kotlin.commonTest.org.antlr.v5.kotlinruntime
 
 import org.antlr.v5.kotlinruntime.CharStreams

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/org/antlr/v4/kotlinruntime/StringCharStreamTest.kt
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/org/antlr/v4/kotlinruntime/StringCharStreamTest.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.test.runtime.kotlin.commonTest.org.antlr.v5.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.ext.codePointIndices

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/org/antlr/v4/kotlinruntime/misc/IntegerListTest.kt
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/kotlin/commonTest/org/antlr/v4/kotlinruntime/misc/IntegerListTest.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.test.runtime.kotlin.commonTest.org.antlr.v5.kotlinruntime.misc
 
 import org.antlr.v5.kotlinruntime.misc.IntegerList

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/states/CompiledState.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/states/CompiledState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/states/ExecutedState.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/states/ExecutedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/states/GeneratedState.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/states/GeneratedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/states/State.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/states/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/states/jvm/JvmCompiledState.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/states/jvm/JvmCompiledState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/states/jvm/JvmExecutedState.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/states/jvm/JvmExecutedState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/typescript/TsNodeRunner.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/typescript/TsNodeRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime-testsuite/test/org/antlr/v5/test/runtime/typescript/TypeScriptRuntimeTests.java
+++ b/runtime-testsuite/test/org/antlr/v5/test/runtime/typescript/TypeScriptRuntimeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/nb-configuration.xml
+++ b/runtime/Java/nb-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/runtime/Java/src/org/antlr/v5/runtime/ANTLRErrorListener.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/ANTLRErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/ANTLRErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/ANTLRErrorStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/ANTLRFileStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/ANTLRFileStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/ANTLRInputStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/ANTLRInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/BailErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/BailErrorStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/BaseErrorListener.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/BaseErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/BufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/BufferedTokenStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/CharStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/CharStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/CharStreams.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/CharStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/CodePointBuffer.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/CodePointBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/CodePointCharStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/CodePointCharStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/CommonToken.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/CommonToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/CommonTokenFactory.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/CommonTokenFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/CommonTokenStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/CommonTokenStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/ConsoleErrorListener.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/ConsoleErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/DefaultErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/DefaultErrorStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/DiagnosticErrorListener.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/DiagnosticErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/FailedPredicateException.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/FailedPredicateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/InputMismatchException.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/InputMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/IntStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/IntStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/InterpreterRuleContext.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/InterpreterRuleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/Lexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/LexerInterpreter.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/LexerInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/LexerNoViableAltException.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/LexerNoViableAltException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/ListTokenSource.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/ListTokenSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/NoViableAltException.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/NoViableAltException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/ParserInterpreter.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/ParserInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/ParserRuleContext.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/ParserRuleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/ProxyErrorListener.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/ProxyErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/RecognitionException.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/RecognitionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/Recognizer.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/Recognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/RuleContext.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/RuleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/RuleContextWithAltNum.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/RuleContextWithAltNum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/RuntimeMetaData.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/RuntimeMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/Token.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/TokenFactory.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/TokenFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/TokenSource.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/TokenSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/TokenStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/TokenStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/TokenStreamRewriter.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/TokenStreamRewriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/UnbufferedCharStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/UnbufferedCharStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/UnbufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/UnbufferedTokenStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/Vocabulary.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/Vocabulary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/VocabularyImpl.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/VocabularyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/WritableToken.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/WritableToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ATN.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ATN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ATNConfig.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ATNConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ATNConfigSet.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ATNConfigSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ATNDeserializationOptions.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ATNDeserializationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ATNDeserializer.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ATNDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ATNSerializer.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ATNSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ATNSimulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ATNState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ATNState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ATNType.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ATNType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/AbstractPredicateTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/AbstractPredicateTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ActionTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ActionTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/AmbiguityInfo.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/AmbiguityInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ArrayPredictionContext.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ArrayPredictionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/AtomTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/AtomTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/BasicBlockStartState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/BasicBlockStartState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/BasicState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/BasicState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/BlockEndState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/BlockEndState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/BlockStartState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/BlockStartState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/CodePointTransitions.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/CodePointTransitions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ContextSensitivityInfo.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ContextSensitivityInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/DecisionEventInfo.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/DecisionEventInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/DecisionInfo.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/DecisionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/DecisionState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/DecisionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/EmptyPredictionContext.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/EmptyPredictionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/EpsilonTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/EpsilonTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ErrorInfo.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ErrorInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LL1Analyzer.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LL1Analyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerATNConfig.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerATNConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerATNSimulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerActionExecutor.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerActionExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerActionType.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerActionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerChannelAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerChannelAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerCustomAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerCustomAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerIndexedCustomAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerIndexedCustomAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerModeAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerModeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerMoreAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerMoreAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerPopModeAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerPopModeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerPushModeAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerPushModeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerSkipAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerSkipAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LexerTypeAction.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LexerTypeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LookaheadEventInfo.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LookaheadEventInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/LoopEndState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/LoopEndState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/NotSetTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/NotSetTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/OrderedATNConfigSet.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/OrderedATNConfigSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ParseInfo.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ParseInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ParserATNSimulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/PlusBlockStartState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/PlusBlockStartState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/PlusLoopbackState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/PlusLoopbackState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/PrecedencePredicateTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/PrecedencePredicateTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/PredicateEvalInfo.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/PredicateEvalInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/PredicateTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/PredicateTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/PredictionContext.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/PredictionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/PredictionContextCache.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/PredictionContextCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/PredictionMode.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/PredictionMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/ProfilingATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/ProfilingATNSimulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/RangeTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/RangeTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/RuleStartState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/RuleStartState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/RuleStopState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/RuleStopState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/RuleTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/RuleTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/SemanticContext.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/SemanticContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/SetTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/SetTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/SingletonPredictionContext.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/SingletonPredictionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/StarBlockStartState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/StarBlockStartState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/StarLoopEntryState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/StarLoopEntryState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/StarLoopbackState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/StarLoopbackState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/TokensStartState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/TokensStartState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/Transition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/Transition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/atn/WildcardTransition.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/atn/WildcardTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/dfa/DFA.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/dfa/DFA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/dfa/DFASerializer.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/dfa/DFASerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/dfa/DFAState.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/dfa/DFAState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/dfa/LexerDFASerializer.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/dfa/LexerDFASerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/AbstractEqualityComparator.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/AbstractEqualityComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/Array2DHashSet.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/Array2DHashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/DoubleKeyMap.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/DoubleKeyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/EqualityComparator.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/EqualityComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/FlexibleHashMap.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/FlexibleHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/IntSet.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/IntSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/IntegerList.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/IntegerList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/IntegerStack.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/IntegerStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/InterpreterDataReader.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/InterpreterDataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/Interval.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/Interval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/IntervalSet.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/IntervalSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/LogManager.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/LogManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/MultiMap.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/MultiMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/MurmurHash.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/MurmurHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/NotNull.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/NotNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/ObjectEqualityComparator.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/ObjectEqualityComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/OrderedHashSet.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/OrderedHashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/Pair.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/ParseCancellationException.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/ParseCancellationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/Predicate.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/Predicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/TestRig.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/TestRig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/Triple.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/Triple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/misc/Utils.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/misc/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/AbstractParseTreeVisitor.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/AbstractParseTreeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/ErrorNode.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/ErrorNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/ErrorNodeImpl.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/ErrorNodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/IterativeParseTreeWalker.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/IterativeParseTreeWalker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTree.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTreeListener.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTreeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTreeProperty.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTreeProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTreeVisitor.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTreeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTreeWalker.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/ParseTreeWalker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/RuleNode.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/RuleNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/SyntaxTree.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/SyntaxTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/TerminalNode.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/TerminalNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/TerminalNodeImpl.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/TerminalNodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/Tree.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/Tree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/Trees.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/Trees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/Chunk.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/Chunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/ParseTreeMatch.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/ParseTreeMatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/ParseTreePattern.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/ParseTreePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/ParseTreePatternMatcher.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/ParseTreePatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/RuleTagToken.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/RuleTagToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/TagChunk.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/TagChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/TextChunk.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/TextChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/TokenTagToken.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/pattern/TokenTagToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPath.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathElement.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathLexer.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathLexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathLexerErrorListener.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathLexerErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathRuleAnywhereElement.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathRuleAnywhereElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathRuleElement.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathRuleElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathTokenAnywhereElement.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathTokenAnywhereElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathTokenElement.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathTokenElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathWildcardAnywhereElement.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathWildcardAnywhereElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathWildcardElement.java
+++ b/runtime/Java/src/org/antlr/v5/runtime/tree/xpath/XPathWildcardElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/BufferedTokenStream.js
+++ b/runtime/JavaScript/src/antlr4/BufferedTokenStream.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/CharStream.js
+++ b/runtime/JavaScript/src/antlr4/CharStream.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/CharStreams.js
+++ b/runtime/JavaScript/src/antlr4/CharStreams.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/CommonTokenFactory.js
+++ b/runtime/JavaScript/src/antlr4/CommonTokenFactory.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/CommonTokenStream.js
+++ b/runtime/JavaScript/src/antlr4/CommonTokenStream.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/FileStream.js
+++ b/runtime/JavaScript/src/antlr4/FileStream.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/InputStream.js
+++ b/runtime/JavaScript/src/antlr4/InputStream.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/Lexer.js
+++ b/runtime/JavaScript/src/antlr4/Lexer.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/Parser.js
+++ b/runtime/JavaScript/src/antlr4/Parser.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/Recognizer.js
+++ b/runtime/JavaScript/src/antlr4/Recognizer.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/Token.js
+++ b/runtime/JavaScript/src/antlr4/Token.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/TokenSource.js
+++ b/runtime/JavaScript/src/antlr4/TokenSource.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/TokenStream.js
+++ b/runtime/JavaScript/src/antlr4/TokenStream.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/TraceListener.js
+++ b/runtime/JavaScript/src/antlr4/TraceListener.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerAction.js
@@ -1,10 +1,10 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
 import HashCode from "../misc/HashCode.js";
 
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerChannelAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerChannelAction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerCustomAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerCustomAction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerIndexedCustomAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerIndexedCustomAction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerModeAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerModeAction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerMoreAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerMoreAction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerPopModeAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerPopModeAction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerPushModeAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerPushModeAction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerSkipAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerSkipAction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/action/LexerTypeAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerTypeAction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/ATN.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATN.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/ATNConfig.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNConfig.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/ATNConfigSet.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNConfigSet.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/ATNDeserializationOptions.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNDeserializationOptions.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/ATNDeserializer.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNDeserializer.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/ATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNSimulator.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/ATNType.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNType.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/AbstractPredicateTransition.js
+++ b/runtime/JavaScript/src/antlr4/atn/AbstractPredicateTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/LL1Analyzer.js
+++ b/runtime/JavaScript/src/antlr4/atn/LL1Analyzer.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/LexerATNConfig.js
+++ b/runtime/JavaScript/src/antlr4/atn/LexerATNConfig.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/LexerATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/LexerATNSimulator.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/LexerActionExecutor.js
+++ b/runtime/JavaScript/src/antlr4/atn/LexerActionExecutor.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/LexerActionType.js
+++ b/runtime/JavaScript/src/antlr4/atn/LexerActionType.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/OrderedATNConfigSet.js
+++ b/runtime/JavaScript/src/antlr4/atn/OrderedATNConfigSet.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/ParserATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/ParserATNSimulator.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/PrecedencePredicate.js
+++ b/runtime/JavaScript/src/antlr4/atn/PrecedencePredicate.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/Predicate.js
+++ b/runtime/JavaScript/src/antlr4/atn/Predicate.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/PredictionContextCache.js
+++ b/runtime/JavaScript/src/antlr4/atn/PredictionContextCache.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/PredictionMode.js
+++ b/runtime/JavaScript/src/antlr4/atn/PredictionMode.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/SemanticContext.js
+++ b/runtime/JavaScript/src/antlr4/atn/SemanticContext.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/atn/index.js
+++ b/runtime/JavaScript/src/antlr4/atn/index.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/context/ArrayPredictionContext.js
+++ b/runtime/JavaScript/src/antlr4/context/ArrayPredictionContext.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/context/EmptyPredictionContext.js
+++ b/runtime/JavaScript/src/antlr4/context/EmptyPredictionContext.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/context/InterpreterRuleContext.js
+++ b/runtime/JavaScript/src/antlr4/context/InterpreterRuleContext.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/context/ParserRuleContext.js
+++ b/runtime/JavaScript/src/antlr4/context/ParserRuleContext.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/context/PredictionContext.js
+++ b/runtime/JavaScript/src/antlr4/context/PredictionContext.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/context/PredictionContextUtils.js
+++ b/runtime/JavaScript/src/antlr4/context/PredictionContextUtils.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/context/RuleContext.js
+++ b/runtime/JavaScript/src/antlr4/context/RuleContext.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/context/SingletonPredictionContext.js
+++ b/runtime/JavaScript/src/antlr4/context/SingletonPredictionContext.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/context/index.js
+++ b/runtime/JavaScript/src/antlr4/context/index.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/dfa/DFA.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFA.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/dfa/DFAState.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFAState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/dfa/LexerDFASerializer.js
+++ b/runtime/JavaScript/src/antlr4/dfa/LexerDFASerializer.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/dfa/PredPrediction.js
+++ b/runtime/JavaScript/src/antlr4/dfa/PredPrediction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/dfa/index.js
+++ b/runtime/JavaScript/src/antlr4/dfa/index.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/BailErrorStrategy.js
+++ b/runtime/JavaScript/src/antlr4/error/BailErrorStrategy.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/ConsoleErrorListener.js
+++ b/runtime/JavaScript/src/antlr4/error/ConsoleErrorListener.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/DefaultErrorStrategy.js
+++ b/runtime/JavaScript/src/antlr4/error/DefaultErrorStrategy.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/DiagnosticErrorListener.js
+++ b/runtime/JavaScript/src/antlr4/error/DiagnosticErrorListener.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/ErrorListener.js
+++ b/runtime/JavaScript/src/antlr4/error/ErrorListener.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
+++ b/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/FailedPredicateException.js
+++ b/runtime/JavaScript/src/antlr4/error/FailedPredicateException.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/InputMismatchException.js
+++ b/runtime/JavaScript/src/antlr4/error/InputMismatchException.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/LexerNoViableAltException.js
+++ b/runtime/JavaScript/src/antlr4/error/LexerNoViableAltException.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/NoViableAltException.js
+++ b/runtime/JavaScript/src/antlr4/error/NoViableAltException.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/ParseCancellationException.js
+++ b/runtime/JavaScript/src/antlr4/error/ParseCancellationException.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/ProxyErrorListener.js
+++ b/runtime/JavaScript/src/antlr4/error/ProxyErrorListener.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/RecognitionException.js
+++ b/runtime/JavaScript/src/antlr4/error/RecognitionException.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/error/index.js
+++ b/runtime/JavaScript/src/antlr4/error/index.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/index.node.js
+++ b/runtime/JavaScript/src/antlr4/index.node.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/index.web.js
+++ b/runtime/JavaScript/src/antlr4/index.web.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/misc/AltDict.js
+++ b/runtime/JavaScript/src/antlr4/misc/AltDict.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/misc/BitSet.js
+++ b/runtime/JavaScript/src/antlr4/misc/BitSet.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/misc/HashCode.js
+++ b/runtime/JavaScript/src/antlr4/misc/HashCode.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/misc/HashMap.js
+++ b/runtime/JavaScript/src/antlr4/misc/HashMap.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/misc/HashSet.js
+++ b/runtime/JavaScript/src/antlr4/misc/HashSet.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/misc/Interval.js
+++ b/runtime/JavaScript/src/antlr4/misc/Interval.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/misc/IntervalSet.js
+++ b/runtime/JavaScript/src/antlr4/misc/IntervalSet.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/ATNState.js
+++ b/runtime/JavaScript/src/antlr4/state/ATNState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/BasicBlockStartState.js
+++ b/runtime/JavaScript/src/antlr4/state/BasicBlockStartState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/BasicState.js
+++ b/runtime/JavaScript/src/antlr4/state/BasicState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/BlockEndState.js
+++ b/runtime/JavaScript/src/antlr4/state/BlockEndState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/BlockStartState.js
+++ b/runtime/JavaScript/src/antlr4/state/BlockStartState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/DecisionState.js
+++ b/runtime/JavaScript/src/antlr4/state/DecisionState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/LoopEndState.js
+++ b/runtime/JavaScript/src/antlr4/state/LoopEndState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/PlusBlockStartState.js
+++ b/runtime/JavaScript/src/antlr4/state/PlusBlockStartState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/PlusLoopbackState.js
+++ b/runtime/JavaScript/src/antlr4/state/PlusLoopbackState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/RuleStartState.js
+++ b/runtime/JavaScript/src/antlr4/state/RuleStartState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/RuleStopState.js
+++ b/runtime/JavaScript/src/antlr4/state/RuleStopState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/StarBlockStartState.js
+++ b/runtime/JavaScript/src/antlr4/state/StarBlockStartState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/StarLoopEntryState.js
+++ b/runtime/JavaScript/src/antlr4/state/StarLoopEntryState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/StarLoopbackState.js
+++ b/runtime/JavaScript/src/antlr4/state/StarLoopbackState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/state/TokensStartState.js
+++ b/runtime/JavaScript/src/antlr4/state/TokensStartState.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/ActionTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/ActionTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/AtomTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/AtomTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/EpsilonTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/EpsilonTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/NotSetTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/NotSetTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/PrecedencePredicateTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/PrecedencePredicateTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/PredicateTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/PredicateTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/RangeTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/RangeTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/RuleTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/RuleTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/SetTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/SetTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/Transition.js
+++ b/runtime/JavaScript/src/antlr4/transition/Transition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/transition/WildcardTransition.js
+++ b/runtime/JavaScript/src/antlr4/transition/WildcardTransition.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/ErrorNode.js
+++ b/runtime/JavaScript/src/antlr4/tree/ErrorNode.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/ErrorNodeImpl.js
+++ b/runtime/JavaScript/src/antlr4/tree/ErrorNodeImpl.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/ParseTree.js
+++ b/runtime/JavaScript/src/antlr4/tree/ParseTree.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/ParseTreeListener.js
+++ b/runtime/JavaScript/src/antlr4/tree/ParseTreeListener.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/ParseTreeVisitor.js
+++ b/runtime/JavaScript/src/antlr4/tree/ParseTreeVisitor.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/ParseTreeWalker.js
+++ b/runtime/JavaScript/src/antlr4/tree/ParseTreeWalker.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/RuleNode.js
+++ b/runtime/JavaScript/src/antlr4/tree/RuleNode.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/SyntaxTree.js
+++ b/runtime/JavaScript/src/antlr4/tree/SyntaxTree.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/TerminalNode.js
+++ b/runtime/JavaScript/src/antlr4/tree/TerminalNode.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/TerminalNodeImpl.js
+++ b/runtime/JavaScript/src/antlr4/tree/TerminalNodeImpl.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/Trees.js
+++ b/runtime/JavaScript/src/antlr4/tree/Trees.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/tree/index.js
+++ b/runtime/JavaScript/src/antlr4/tree/index.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/DoubleDict.js
+++ b/runtime/JavaScript/src/antlr4/utils/DoubleDict.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/arrayToString.js
+++ b/runtime/JavaScript/src/antlr4/utils/arrayToString.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/equalArrays.js
+++ b/runtime/JavaScript/src/antlr4/utils/equalArrays.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/escapeWhitespace.js
+++ b/runtime/JavaScript/src/antlr4/utils/escapeWhitespace.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/index.js
+++ b/runtime/JavaScript/src/antlr4/utils/index.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/standardEqualsFunction.js
+++ b/runtime/JavaScript/src/antlr4/utils/standardEqualsFunction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/standardHashCodeFunction.js
+++ b/runtime/JavaScript/src/antlr4/utils/standardHashCodeFunction.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/stringHashCode.js
+++ b/runtime/JavaScript/src/antlr4/utils/stringHashCode.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/titleCase.js
+++ b/runtime/JavaScript/src/antlr4/utils/titleCase.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/JavaScript/src/antlr4/utils/valueToString.js
+++ b/runtime/JavaScript/src/antlr4/utils/valueToString.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved.
+/* Copyright (c) 2012-present The ANTLR Project Contributors. All rights reserved.
  * Use is of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/runtime/Kotlin/pom.xml
+++ b/runtime/Kotlin/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/Assert.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/Assert.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 import kotlin.contracts.ExperimentalContracts

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/CodePoint.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/CodePoint.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 // Note: Kotlin Native has constants named in the same way.

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/Collections.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/Collections.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 public object Collections {

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/SimpleBitSet.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/SimpleBitSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 import kotlin.math.min

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/System.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/System.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 public object System {

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/Appendable.ext.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/Appendable.ext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime.ext
 
 import com.strumenta.antlrkotlin.runtime.highSurrogate

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/Array.ext.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/Array.ext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime.ext
 
 // See Java's Arrays.binarySearch0

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/Char.ext.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/Char.ext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime.ext
 
 import com.strumenta.antlrkotlin.runtime.*

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/Int.ext.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/Int.ext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime.ext
 
 @OptIn(ExperimentalStdlibApi::class)

--- a/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/String.ext.kt
+++ b/runtime/Kotlin/src/com/strumenta/antlrkotlin/runtime/ext/String.ext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime.ext
 
 public fun String.codePointIndices(): IntArray {

--- a/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/BitSet.kt
+++ b/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/BitSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package com.strumenta.antlrkotlin.runtime
 

--- a/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 @file:Suppress("NOTHING_TO_INLINE")
 
 package com.strumenta.antlrkotlin.runtime

--- a/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 public typealias CopyOnWriteArrayList<E> = java.util.concurrent.CopyOnWriteArrayList<E>

--- a/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/Environment.kt
+++ b/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/Environment.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 import java.lang.System as JavaSystem

--- a/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package com.strumenta.antlrkotlin.runtime
 

--- a/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package com.strumenta.antlrkotlin.runtime
 
 public inline fun <R> synchronized(lock: Any, block: () -> R): R =

--- a/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
+++ b/runtime/Kotlin/src/jvm/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package com.strumenta.antlrkotlin.runtime
 

--- a/runtime/Kotlin/src/jvm/org/antlr/v4/kotlinruntime/CharStreams.kt
+++ b/runtime/Kotlin/src/jvm/org/antlr/v4/kotlinruntime/CharStreams.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ANTLRErrorListener.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ANTLRErrorListener.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ANTLRErrorStrategy.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ANTLRErrorStrategy.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ANTLRInputStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ANTLRInputStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.assert

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/AbstractCharStreams.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/AbstractCharStreams.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import kotlin.jvm.JvmOverloads

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/BailErrorStrategy.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/BailErrorStrategy.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/BaseErrorListener.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/BaseErrorListener.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.BitSet

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/BufferedTokenStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/BufferedTokenStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/CharStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/CharStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/CommonToken.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/CommonToken.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import org.antlr.v5.kotlinruntime.misc.Interval

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/CommonTokenFactory.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/CommonTokenFactory.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/CommonTokenStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/CommonTokenStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ConsoleErrorListener.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ConsoleErrorListener.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.System

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/DefaultErrorStrategy.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/DefaultErrorStrategy.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/DiagnosticErrorListener.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/DiagnosticErrorListener.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/DummyCharStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/DummyCharStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import org.antlr.v5.kotlinruntime.misc.Interval

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/DummyTokenStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/DummyTokenStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import org.antlr.v5.kotlinruntime.misc.Interval

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/EmptyStackException.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/EmptyStackException.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/FailedPredicateException.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/FailedPredicateException.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import org.antlr.v5.kotlinruntime.atn.AbstractPredicateTransition

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/InputMismatchException.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/InputMismatchException.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/IntStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/IntStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/InterpreterRuleContext.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/InterpreterRuleContext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Lexer.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Lexer.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.System

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/LexerInterpreter.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/LexerInterpreter.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/LexerNoViableAltException.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/LexerNoViableAltException.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ListTokenSource.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ListTokenSource.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/NoViableAltException.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/NoViableAltException.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import org.antlr.v5.kotlinruntime.atn.ATNConfigSet

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Parser.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Parser.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.System

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ParserInterpreter.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ParserInterpreter.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ParserRuleContext.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ParserRuleContext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import org.antlr.v5.kotlinruntime.ast.Position

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ProxyErrorListener.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ProxyErrorListener.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.BitSet

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/RecognitionException.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/RecognitionException.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import org.antlr.v5.kotlinruntime.atn.DecisionState

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Recognizer.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Recognizer.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/RuleContext.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/RuleContext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import org.antlr.v5.kotlinruntime.atn.ATN

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/RuleContextWithAltNum.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/RuleContextWithAltNum.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/RuntimeMetaData.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/RuntimeMetaData.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/StringCharStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/StringCharStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.assert

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Token.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Token.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/TokenFactory.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/TokenFactory.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/TokenSource.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/TokenSource.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/TokenStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/TokenStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/TokenStreamRewriter.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/TokenStreamRewriter.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.System

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/UnbufferedTokenStream.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/UnbufferedTokenStream.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Vocabulary.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/Vocabulary.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/VocabularyImpl.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/VocabularyImpl.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime
 
 import kotlin.math.max

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/WritableToken.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/WritableToken.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ast/Node.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ast/Node.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.ast
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ast/Point.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ast/Point.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.ast
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ast/Position.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/ast/Position.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.ast
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATN.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATN.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNConfig.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNConfig.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNConfigSet.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNConfigSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNDeserializationOptions.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNDeserializationOptions.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNDeserializer.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNDeserializer.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNSerializer.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNSerializer.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNSimulator.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNSimulator.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNType.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ATNType.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/AbstractPredicateTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/AbstractPredicateTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ActionTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ActionTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/AmbiguityInfo.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/AmbiguityInfo.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ArrayPredictionContext.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ArrayPredictionContext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/AtomTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/AtomTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/BasicBlockStartState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/BasicBlockStartState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/BasicState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/BasicState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/BlockEndState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/BlockEndState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/BlockStartState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/BlockStartState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/CodePointTransitions.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/CodePointTransitions.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ContextSensitivityInfo.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ContextSensitivityInfo.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/DecisionEventInfo.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/DecisionEventInfo.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/DecisionInfo.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/DecisionInfo.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/DecisionState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/DecisionState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/EmptyPredictionContext.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/EmptyPredictionContext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/EpsilonTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/EpsilonTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ErrorInfo.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ErrorInfo.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LL1Analyzer.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LL1Analyzer.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerATNConfig.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerATNConfig.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerATNSimulator.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerATNSimulator.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerActionExecutor.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerActionExecutor.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerActionType.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerActionType.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerChannelAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerChannelAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerCustomAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerCustomAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerIndexedCustomAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerIndexedCustomAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerModeAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerModeAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerMoreAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerMoreAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerPopModeAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerPopModeAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerPushModeAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerPushModeAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerSkipAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerSkipAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerTypeAction.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LexerTypeAction.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LookaheadEventInfo.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LookaheadEventInfo.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LoopEndState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/LoopEndState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/NotSetTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/NotSetTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/OrderedATNConfigSet.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/OrderedATNConfigSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ParseInfo.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ParseInfo.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ParserATNSimulator.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ParserATNSimulator.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PlusBlockStartState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PlusBlockStartState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PlusLoopbackState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PlusLoopbackState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PrecedencePredicateTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PrecedencePredicateTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredicateEvalInfo.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredicateEvalInfo.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredicateTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredicateTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredictionContext.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredictionContext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredictionContextCache.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredictionContextCache.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredictionMode.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/PredictionMode.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ProfilingATNSimulator.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/ProfilingATNSimulator.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/RangeTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/RangeTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/RuleStartState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/RuleStartState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/RuleStopState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/RuleStopState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/RuleTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/RuleTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/SemanticContext.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/SemanticContext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/SetTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/SetTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/SingletonPredictionContext.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/SingletonPredictionContext.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/StarBlockStartState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/StarBlockStartState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/StarLoopEntryState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/StarLoopEntryState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/StarLoopbackState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/StarLoopbackState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/TokensStartState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/TokensStartState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/Transition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/Transition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/WildcardTransition.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/atn/WildcardTransition.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.atn
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/dfa/DFA.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/dfa/DFA.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.dfa
 
 import com.strumenta.antlrkotlin.runtime.synchronized

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/dfa/DFASerializer.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/dfa/DFASerializer.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.dfa
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/dfa/DFAState.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/dfa/DFAState.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.dfa
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/dfa/LexerDFASerializer.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/dfa/LexerDFASerializer.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.dfa
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/AbstractEqualityComparator.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/AbstractEqualityComparator.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.misc
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/Array2DHashSet.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/Array2DHashSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/DoubleKeyMap.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/DoubleKeyMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/EqualityComparator.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/EqualityComparator.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.misc
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/FlexibleHashMap.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/FlexibleHashMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/IntSet.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/IntSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.misc
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/IntegerList.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/IntegerList.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.misc
 
 import com.strumenta.antlrkotlin.runtime.System

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/IntegerStack.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/IntegerStack.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.misc
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/InterpreterDataReader.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/InterpreterDataReader.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/Interval.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/Interval.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.misc
 
 import kotlin.math.max

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/IntervalSet.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/IntervalSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.misc
 
 import com.strumenta.antlrkotlin.runtime.ext.appendCodePoint

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/MultiMap.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/MultiMap.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/MurmurHash.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/MurmurHash.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/ObjectEqualityComparator.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/ObjectEqualityComparator.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.misc
 
 /**

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/OrderedHashSet.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/OrderedHashSet.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/ParseCancellationException.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/ParseCancellationException.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/Predicate.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/Predicate.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/Utils.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/misc/Utils.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.misc
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/AbstractParseTreeVisitor.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/AbstractParseTreeVisitor.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ErrorNode.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ErrorNode.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ErrorNodeImpl.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ErrorNodeImpl.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/IterativeParseTreeWalker.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/IterativeParseTreeWalker.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTree.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTree.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTreeListener.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTreeListener.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTreeProperty.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTreeProperty.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTreeVisitor.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTreeVisitor.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTreeWalker.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/ParseTreeWalker.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/RuleNode.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/RuleNode.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/SyntaxTree.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/SyntaxTree.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/TerminalNode.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/TerminalNode.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/TerminalNodeImpl.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/TerminalNodeImpl.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/Tree.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/Tree.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/Trees.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/Trees.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/Chunk.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/Chunk.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree.pattern
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/ParseTreeMatch.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/ParseTreeMatch.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree.pattern
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/ParseTreePattern.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/ParseTreePattern.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree.pattern
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/ParseTreePatternMatcher.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/ParseTreePatternMatcher.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree.pattern
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/RuleTagToken.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/RuleTagToken.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree.pattern
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/TagChunk.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/TagChunk.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree.pattern
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/TextChunk.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/TextChunk.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree.pattern
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/TokenTagToken.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/pattern/TokenTagToken.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 package org.antlr.v5.kotlinruntime.tree.pattern
 

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPath.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPath.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.tree.xpath
 
 import org.antlr.v5.kotlinruntime.*

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathElement.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathElement.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.tree.xpath
 
 import org.antlr.v5.kotlinruntime.tree.ParseTree

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathLexer.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathLexer.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 //
 // This lexer is generated from antlr-kotlin-tests/antlr/XPathLexer.g4 and formatted manually.

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathLexerErrorListener.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathLexerErrorListener.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.tree.xpath
 
 import org.antlr.v5.kotlinruntime.BaseErrorListener

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathRuleAnywhereElement.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathRuleAnywhereElement.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.tree.xpath
 
 import org.antlr.v5.kotlinruntime.tree.ParseTree

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathRuleElement.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathRuleElement.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.tree.xpath
 
 import org.antlr.v5.kotlinruntime.ParserRuleContext

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathTokenAnywhereElement.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathTokenAnywhereElement.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.tree.xpath
 
 import org.antlr.v5.kotlinruntime.tree.ParseTree

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathTokenElement.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathTokenElement.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.tree.xpath
 
 import org.antlr.v5.kotlinruntime.tree.ParseTree

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathWildcardAnywhereElement.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathWildcardAnywhereElement.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.tree.xpath
 
 import org.antlr.v5.kotlinruntime.tree.ParseTree

--- a/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathWildcardElement.kt
+++ b/runtime/Kotlin/src/org/antlr/v5/kotlinruntime/tree/xpath/XPathWildcardElement.kt
@@ -1,5 +1,8 @@
-// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v5.kotlinruntime.tree.xpath
 
 import org.antlr.v5.kotlinruntime.tree.ParseTree

--- a/tool-testsuite/pom.xml
+++ b/tool-testsuite/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/tool-testsuite/test/org/antlr/v5/test/tool/InterpreterTreeTextProvider.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/InterpreterTreeTextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/JavaUnicodeInputStream.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/JavaUnicodeInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/ParserInterpreterForTesting.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/ParserInterpreterForTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestASTStructure.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestASTStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestATNConstruction.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestATNConstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestATNDeserialization.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestATNDeserialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestATNInterpreter.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestATNInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestATNLexerInterpreter.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestATNLexerInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestATNParserPrediction.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestATNParserPrediction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestATNSerialization.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestATNSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestActionSplitter.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestActionSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestActionTranslation.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestActionTranslation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestAmbigParseTrees.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestAmbigParseTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestAttributeChecks.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestAttributeChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestBasicSemanticErrors.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestBasicSemanticErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestBufferedTokenStream.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestBufferedTokenStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestCharSupport.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestCharSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestCodeGeneration.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestCodeGeneration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestCommonTokenStream.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestCommonTokenStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestCompositeGrammars.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestCompositeGrammars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestDollarParser.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestDollarParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestErrorSets.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestErrorSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestEscapeSequenceParsing.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestEscapeSequenceParsing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestFastQueue.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestFastQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestGrammarParserInterpreter.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestGrammarParserInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestGraphNodes.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestGraphNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestIntervalSet.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestIntervalSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestLeftRecursionToolIssues.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestLeftRecursionToolIssues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestLexerActions.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestLexerActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestLookaheadTrees.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestLookaheadTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestParseTreeMatcher.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestParseTreeMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestParserExec.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestParserExec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestParserInterpreter.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestParserInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestParserProfiler.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestParserProfiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestPerformance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestScopeParsing.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestScopeParsing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestSymbolIssues.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestSymbolIssues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestTokenPositionOptions.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestTokenPositionOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestTokenTypeAssignment.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestTokenTypeAssignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestToolSyntaxErrors.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestToolSyntaxErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestTopologicalSort.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestTopologicalSort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestUnbufferedCharStream.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestUnbufferedCharStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestUnbufferedTokenStream.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestUnbufferedTokenStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestUnicodeData.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestUnicodeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestUnicodeEscapes.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestUnicodeEscapes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestUnicodeGrammar.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestUnicodeGrammar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestVocabulary.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestVocabulary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/TestXPath.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/TestXPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool-testsuite/test/org/antlr/v5/test/tool/ToolTestUtils.java
+++ b/tool-testsuite/test/org/antlr/v5/test/tool/ToolTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/nb-configuration.xml
+++ b/tool/nb-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+  ~ Copyright (c) 2012-present The ANTLR Project. All rights reserved.
   ~ Use of this file is governed by the BSD 3-clause license that
   ~ can be found in the LICENSE.txt file in the project root.
   -->

--- a/tool/resources/org/antlr/v5/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/tool/resources/org/antlr/v5/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -1,5 +1,8 @@
-// Copyright 2017-2024 Strumenta and contributors, licensed under Apache 2.0.
-// Copyright 2024 Strumenta and contributors, licensed under BSD 3-Clause.
+/*
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 
 // Translates types used in the ANTLR grammar
 // to types used by the Kotlin language

--- a/tool/resources/org/antlr/v5/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v5/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -1,4 +1,4 @@
-// Copyright 2016-2022 The ANTLR Project. All rights reserved.
+// Copyright 2016-present The ANTLR Project. All rights reserved.
 // Licensed under the BSD-3-Clause license. See LICENSE file in the project root for license information.
 
 typescriptTypeInitMap ::= [

--- a/tool/src/org/antlr/v5/Tool.java
+++ b/tool/src/org/antlr/v5/Tool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/analysis/AnalysisPipeline.java
+++ b/tool/src/org/antlr/v5/analysis/AnalysisPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/analysis/LeftRecursionDetector.java
+++ b/tool/src/org/antlr/v5/analysis/LeftRecursionDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/analysis/LeftRecursiveRuleAltInfo.java
+++ b/tool/src/org/antlr/v5/analysis/LeftRecursiveRuleAltInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/analysis/LeftRecursiveRuleAnalyzer.java
+++ b/tool/src/org/antlr/v5/analysis/LeftRecursiveRuleAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/analysis/LeftRecursiveRuleTransformer.java
+++ b/tool/src/org/antlr/v5/analysis/LeftRecursiveRuleTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/automata/ATNFactory.java
+++ b/tool/src/org/antlr/v5/automata/ATNFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/automata/ATNOptimizer.java
+++ b/tool/src/org/antlr/v5/automata/ATNOptimizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/automata/ATNPrinter.java
+++ b/tool/src/org/antlr/v5/automata/ATNPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/automata/ATNVisitor.java
+++ b/tool/src/org/antlr/v5/automata/ATNVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/automata/LexerATNFactory.java
+++ b/tool/src/org/antlr/v5/automata/LexerATNFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/automata/ParserATNFactory.java
+++ b/tool/src/org/antlr/v5/automata/ParserATNFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/automata/TailEpsilonRemover.java
+++ b/tool/src/org/antlr/v5/automata/TailEpsilonRemover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/ActionTranslator.java
+++ b/tool/src/org/antlr/v5/codegen/ActionTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/BlankOutputModelFactory.java
+++ b/tool/src/org/antlr/v5/codegen/BlankOutputModelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/CodeGenPipeline.java
+++ b/tool/src/org/antlr/v5/codegen/CodeGenPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/CodeGenerator.java
+++ b/tool/src/org/antlr/v5/codegen/CodeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/CodeGeneratorExtension.java
+++ b/tool/src/org/antlr/v5/codegen/CodeGeneratorExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/DefaultOutputModelFactory.java
+++ b/tool/src/org/antlr/v5/codegen/DefaultOutputModelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/LexerFactory.java
+++ b/tool/src/org/antlr/v5/codegen/LexerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/OutputModelController.java
+++ b/tool/src/org/antlr/v5/codegen/OutputModelController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/OutputModelFactory.java
+++ b/tool/src/org/antlr/v5/codegen/OutputModelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/OutputModelWalker.java
+++ b/tool/src/org/antlr/v5/codegen/OutputModelWalker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/ParserFactory.java
+++ b/tool/src/org/antlr/v5/codegen/ParserFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/Target.java
+++ b/tool/src/org/antlr/v5/codegen/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/UnicodeEscapes.java
+++ b/tool/src/org/antlr/v5/codegen/UnicodeEscapes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/Action.java
+++ b/tool/src/org/antlr/v5/codegen/model/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/AddToLabelList.java
+++ b/tool/src/org/antlr/v5/codegen/model/AddToLabelList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/AltBlock.java
+++ b/tool/src/org/antlr/v5/codegen/model/AltBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ArgAction.java
+++ b/tool/src/org/antlr/v5/codegen/model/ArgAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/BaseListenerFile.java
+++ b/tool/src/org/antlr/v5/codegen/model/BaseListenerFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/BaseVisitorFile.java
+++ b/tool/src/org/antlr/v5/codegen/model/BaseVisitorFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/CaptureNextToken.java
+++ b/tool/src/org/antlr/v5/codegen/model/CaptureNextToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/CaptureNextTokenType.java
+++ b/tool/src/org/antlr/v5/codegen/model/CaptureNextTokenType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/Choice.java
+++ b/tool/src/org/antlr/v5/codegen/model/Choice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/CodeBlockForAlt.java
+++ b/tool/src/org/antlr/v5/codegen/model/CodeBlockForAlt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/CodeBlockForOuterMostAlt.java
+++ b/tool/src/org/antlr/v5/codegen/model/CodeBlockForOuterMostAlt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/DispatchMethod.java
+++ b/tool/src/org/antlr/v5/codegen/model/DispatchMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ElementFrequenciesVisitor.java
+++ b/tool/src/org/antlr/v5/codegen/model/ElementFrequenciesVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ExceptionClause.java
+++ b/tool/src/org/antlr/v5/codegen/model/ExceptionClause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/InvokeRule.java
+++ b/tool/src/org/antlr/v5/codegen/model/InvokeRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LL1AltBlock.java
+++ b/tool/src/org/antlr/v5/codegen/model/LL1AltBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LL1Choice.java
+++ b/tool/src/org/antlr/v5/codegen/model/LL1Choice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LL1Loop.java
+++ b/tool/src/org/antlr/v5/codegen/model/LL1Loop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LL1OptionalBlock.java
+++ b/tool/src/org/antlr/v5/codegen/model/LL1OptionalBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LL1OptionalBlockSingleAlt.java
+++ b/tool/src/org/antlr/v5/codegen/model/LL1OptionalBlockSingleAlt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LL1PlusBlockSingleAlt.java
+++ b/tool/src/org/antlr/v5/codegen/model/LL1PlusBlockSingleAlt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LL1StarBlockSingleAlt.java
+++ b/tool/src/org/antlr/v5/codegen/model/LL1StarBlockSingleAlt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LabeledOp.java
+++ b/tool/src/org/antlr/v5/codegen/model/LabeledOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LeftRecursiveRuleFunction.java
+++ b/tool/src/org/antlr/v5/codegen/model/LeftRecursiveRuleFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/Lexer.java
+++ b/tool/src/org/antlr/v5/codegen/model/Lexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/LexerFile.java
+++ b/tool/src/org/antlr/v5/codegen/model/LexerFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ListenerDispatchMethod.java
+++ b/tool/src/org/antlr/v5/codegen/model/ListenerDispatchMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ListenerFile.java
+++ b/tool/src/org/antlr/v5/codegen/model/ListenerFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/Loop.java
+++ b/tool/src/org/antlr/v5/codegen/model/Loop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/MatchNotSet.java
+++ b/tool/src/org/antlr/v5/codegen/model/MatchNotSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/MatchSet.java
+++ b/tool/src/org/antlr/v5/codegen/model/MatchSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/MatchToken.java
+++ b/tool/src/org/antlr/v5/codegen/model/MatchToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ModelElement.java
+++ b/tool/src/org/antlr/v5/codegen/model/ModelElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/OptionalBlock.java
+++ b/tool/src/org/antlr/v5/codegen/model/OptionalBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/OutputFile.java
+++ b/tool/src/org/antlr/v5/codegen/model/OutputFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/OutputModelObject.java
+++ b/tool/src/org/antlr/v5/codegen/model/OutputModelObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/Parser.java
+++ b/tool/src/org/antlr/v5/codegen/model/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ParserFile.java
+++ b/tool/src/org/antlr/v5/codegen/model/ParserFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/PlusBlock.java
+++ b/tool/src/org/antlr/v5/codegen/model/PlusBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/Recognizer.java
+++ b/tool/src/org/antlr/v5/codegen/model/Recognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/RuleActionFunction.java
+++ b/tool/src/org/antlr/v5/codegen/model/RuleActionFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/RuleElement.java
+++ b/tool/src/org/antlr/v5/codegen/model/RuleElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v5/codegen/model/RuleFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/RuleSempredFunction.java
+++ b/tool/src/org/antlr/v5/codegen/model/RuleSempredFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/SemPred.java
+++ b/tool/src/org/antlr/v5/codegen/model/SemPred.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/SerializedATN.java
+++ b/tool/src/org/antlr/v5/codegen/model/SerializedATN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/SrcOp.java
+++ b/tool/src/org/antlr/v5/codegen/model/SrcOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/StarBlock.java
+++ b/tool/src/org/antlr/v5/codegen/model/StarBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/Sync.java
+++ b/tool/src/org/antlr/v5/codegen/model/Sync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/TestSetInline.java
+++ b/tool/src/org/antlr/v5/codegen/model/TestSetInline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ThrowEarlyExitException.java
+++ b/tool/src/org/antlr/v5/codegen/model/ThrowEarlyExitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ThrowNoViableAlt.java
+++ b/tool/src/org/antlr/v5/codegen/model/ThrowNoViableAlt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/ThrowRecognitionException.java
+++ b/tool/src/org/antlr/v5/codegen/model/ThrowRecognitionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/VisitorDispatchMethod.java
+++ b/tool/src/org/antlr/v5/codegen/model/VisitorDispatchMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/VisitorFile.java
+++ b/tool/src/org/antlr/v5/codegen/model/VisitorFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/Wildcard.java
+++ b/tool/src/org/antlr/v5/codegen/model/Wildcard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ActionChunk.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ActionChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ActionTemplate.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ActionTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ActionText.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ActionText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ArgRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ArgRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/LabelRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/LabelRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ListLabelRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ListLabelRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/LocalRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/LocalRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/NonLocalAttrRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/NonLocalAttrRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/QRetValueRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/QRetValueRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/RetValueRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/RetValueRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_ctx.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_ctx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_parser.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_start.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_start.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_stop.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_stop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_text.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/RulePropertyRef_text.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/SetAttr.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/SetAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/SetNonLocalAttr.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/SetNonLocalAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_ctx.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_ctx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_parser.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_start.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_start.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_stop.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_stop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_text.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/ThisRulePropertyRef_text.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_channel.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_channel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_index.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_index.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_int.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_line.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_line.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_pos.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_pos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_text.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_text.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_type.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/TokenPropertyRef_type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/chunk/TokenRef.java
+++ b/tool/src/org/antlr/v5/codegen/model/chunk/TokenRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/dbg.java
+++ b/tool/src/org/antlr/v5/codegen/model/dbg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/AltLabelStructDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/AltLabelStructDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/AttributeDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/AttributeDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/CodeBlock.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/CodeBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/ContextGetterDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/ContextGetterDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/ContextRuleGetterDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/ContextRuleGetterDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/ContextRuleListGetterDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/ContextRuleListGetterDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/ContextRuleListIndexedGetterDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/ContextRuleListIndexedGetterDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/ContextTokenGetterDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/ContextTokenGetterDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/ContextTokenListGetterDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/ContextTokenListGetterDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/ContextTokenListIndexedGetterDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/ContextTokenListIndexedGetterDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/Decl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/Decl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/ElementListDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/ElementListDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/RuleContextDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/RuleContextDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/RuleContextListDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/RuleContextListDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/StructDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/StructDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/TokenDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/TokenDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/TokenListDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/TokenListDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/model/decl/TokenTypeDecl.java
+++ b/tool/src/org/antlr/v5/codegen/model/decl/TokenTypeDecl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/CSharpTarget.java
+++ b/tool/src/org/antlr/v5/codegen/target/CSharpTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/CppTarget.java
+++ b/tool/src/org/antlr/v5/codegen/target/CppTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/DartTarget.java
+++ b/tool/src/org/antlr/v5/codegen/target/DartTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v5/codegen/target/GoTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/JavaScriptTarget.java
+++ b/tool/src/org/antlr/v5/codegen/target/JavaScriptTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/JavaTarget.java
+++ b/tool/src/org/antlr/v5/codegen/target/JavaTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/PHPTarget.java
+++ b/tool/src/org/antlr/v5/codegen/target/PHPTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/Python3Target.java
+++ b/tool/src/org/antlr/v5/codegen/target/Python3Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/SwiftTarget.java
+++ b/tool/src/org/antlr/v5/codegen/target/SwiftTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/codegen/target/TypeScriptTarget.java
+++ b/tool/src/org/antlr/v5/codegen/target/TypeScriptTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 20162022 The ANTLR Project. All rights reserved.
+ * Copyright 2016-present The ANTLR Project. All rights reserved.
  * Licensed under the BSD-3-Clause license. See LICENSE file in the project root for license information.
  */
 package org.antlr.v5.codegen.target;

--- a/tool/src/org/antlr/v5/gui/BasicFontMetrics.java
+++ b/tool/src/org/antlr/v5/gui/BasicFontMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/GraphicsSupport.java
+++ b/tool/src/org/antlr/v5/gui/GraphicsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/JFileChooserConfirmOverwrite.java
+++ b/tool/src/org/antlr/v5/gui/JFileChooserConfirmOverwrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/PostScriptDocument.java
+++ b/tool/src/org/antlr/v5/gui/PostScriptDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/SystemFontMetrics.java
+++ b/tool/src/org/antlr/v5/gui/SystemFontMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/TestRig.java
+++ b/tool/src/org/antlr/v5/gui/TestRig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/TreeLayoutAdaptor.java
+++ b/tool/src/org/antlr/v5/gui/TreeLayoutAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/TreePostScriptGenerator.java
+++ b/tool/src/org/antlr/v5/gui/TreePostScriptGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/TreeTextProvider.java
+++ b/tool/src/org/antlr/v5/gui/TreeTextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/TreeViewer.java
+++ b/tool/src/org/antlr/v5/gui/TreeViewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/gui/Trees.java
+++ b/tool/src/org/antlr/v5/gui/Trees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/misc/CharSupport.java
+++ b/tool/src/org/antlr/v5/misc/CharSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/misc/EscapeSequenceParsing.java
+++ b/tool/src/org/antlr/v5/misc/EscapeSequenceParsing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/misc/FrequencySet.java
+++ b/tool/src/org/antlr/v5/misc/FrequencySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/misc/Graph.java
+++ b/tool/src/org/antlr/v5/misc/Graph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/misc/MutableInt.java
+++ b/tool/src/org/antlr/v5/misc/MutableInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/misc/OrderedHashMap.java
+++ b/tool/src/org/antlr/v5/misc/OrderedHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/misc/Utils.java
+++ b/tool/src/org/antlr/v5/misc/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/parse/ActionSplitterListener.java
+++ b/tool/src/org/antlr/v5/parse/ActionSplitterListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/parse/GrammarASTAdaptor.java
+++ b/tool/src/org/antlr/v5/parse/GrammarASTAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/parse/GrammarToken.java
+++ b/tool/src/org/antlr/v5/parse/GrammarToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/parse/ResyncToEndOfRuleBlock.java
+++ b/tool/src/org/antlr/v5/parse/ResyncToEndOfRuleBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/parse/ScopeParser.java
+++ b/tool/src/org/antlr/v5/parse/ScopeParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/parse/TokenVocabParser.java
+++ b/tool/src/org/antlr/v5/parse/TokenVocabParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/parse/ToolANTLRLexer.java
+++ b/tool/src/org/antlr/v5/parse/ToolANTLRLexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/parse/ToolANTLRParser.java
+++ b/tool/src/org/antlr/v5/parse/ToolANTLRParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/parse/v4ParserException.java
+++ b/tool/src/org/antlr/v5/parse/v4ParserException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/semantics/ActionSniffer.java
+++ b/tool/src/org/antlr/v5/semantics/ActionSniffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/semantics/AttributeChecks.java
+++ b/tool/src/org/antlr/v5/semantics/AttributeChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/semantics/BasicSemanticChecks.java
+++ b/tool/src/org/antlr/v5/semantics/BasicSemanticChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/semantics/BlankActionSplitterListener.java
+++ b/tool/src/org/antlr/v5/semantics/BlankActionSplitterListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/semantics/RuleCollector.java
+++ b/tool/src/org/antlr/v5/semantics/RuleCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/semantics/SemanticPipeline.java
+++ b/tool/src/org/antlr/v5/semantics/SemanticPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/semantics/SymbolChecks.java
+++ b/tool/src/org/antlr/v5/semantics/SymbolChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/semantics/SymbolCollector.java
+++ b/tool/src/org/antlr/v5/semantics/SymbolCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/semantics/UseDefAnalyzer.java
+++ b/tool/src/org/antlr/v5/semantics/UseDefAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ANTLRMessage.java
+++ b/tool/src/org/antlr/v5/tool/ANTLRMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ANTLRToolListener.java
+++ b/tool/src/org/antlr/v5/tool/ANTLRToolListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/Alternative.java
+++ b/tool/src/org/antlr/v5/tool/Alternative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/Attribute.java
+++ b/tool/src/org/antlr/v5/tool/Attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/AttributeDict.java
+++ b/tool/src/org/antlr/v5/tool/AttributeDict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/AttributeResolver.java
+++ b/tool/src/org/antlr/v5/tool/AttributeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/BuildDependencyGenerator.java
+++ b/tool/src/org/antlr/v5/tool/BuildDependencyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/DOTGenerator.java
+++ b/tool/src/org/antlr/v5/tool/DOTGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/DefaultToolListener.java
+++ b/tool/src/org/antlr/v5/tool/DefaultToolListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ErrorManager.java
+++ b/tool/src/org/antlr/v5/tool/ErrorManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ErrorSeverity.java
+++ b/tool/src/org/antlr/v5/tool/ErrorSeverity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ErrorType.java
+++ b/tool/src/org/antlr/v5/tool/ErrorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/Grammar.java
+++ b/tool/src/org/antlr/v5/tool/Grammar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/GrammarInterpreterRuleContext.java
+++ b/tool/src/org/antlr/v5/tool/GrammarInterpreterRuleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/GrammarParserInterpreter.java
+++ b/tool/src/org/antlr/v5/tool/GrammarParserInterpreter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/GrammarSemanticsMessage.java
+++ b/tool/src/org/antlr/v5/tool/GrammarSemanticsMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/GrammarSyntaxMessage.java
+++ b/tool/src/org/antlr/v5/tool/GrammarSyntaxMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/GrammarTransformPipeline.java
+++ b/tool/src/org/antlr/v5/tool/GrammarTransformPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/LabelElementPair.java
+++ b/tool/src/org/antlr/v5/tool/LabelElementPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/LabelType.java
+++ b/tool/src/org/antlr/v5/tool/LabelType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/LeftRecursionCyclesMessage.java
+++ b/tool/src/org/antlr/v5/tool/LeftRecursionCyclesMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/LeftRecursiveRule.java
+++ b/tool/src/org/antlr/v5/tool/LeftRecursiveRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/LexerGrammar.java
+++ b/tool/src/org/antlr/v5/tool/LexerGrammar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/Rule.java
+++ b/tool/src/org/antlr/v5/tool/Rule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ToolMessage.java
+++ b/tool/src/org/antlr/v5/tool/ToolMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/ActionAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/ActionAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/AltAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/AltAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/BlockAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/BlockAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/GrammarAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/GrammarAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/GrammarASTErrorNode.java
+++ b/tool/src/org/antlr/v5/tool/ast/GrammarASTErrorNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/GrammarASTVisitor.java
+++ b/tool/src/org/antlr/v5/tool/ast/GrammarASTVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/GrammarASTWithOptions.java
+++ b/tool/src/org/antlr/v5/tool/ast/GrammarASTWithOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/GrammarRootAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/GrammarRootAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/NotAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/NotAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/OptionalBlockAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/OptionalBlockAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/PlusBlockAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/PlusBlockAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/PredAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/PredAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/QuantifierAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/QuantifierAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/RangeAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/RangeAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/RuleAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/RuleAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/RuleElementAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/RuleElementAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/RuleRefAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/RuleRefAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/SetAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/SetAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/StarBlockAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/StarBlockAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/tool/ast/TerminalAST.java
+++ b/tool/src/org/antlr/v5/tool/ast/TerminalAST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */

--- a/tool/src/org/antlr/v5/unicode/UnicodeDataTemplateController.java
+++ b/tool/src/org/antlr/v5/unicode/UnicodeDataTemplateController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Copyright (c) 2012-present The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

This PR partially solved #14 by updating the copyright to refer not to "Strumenta and contributors" but to "The ANTLR project". It also updates all copyright messages to be extended to the present time and not "end" in certain years (2018, 2022, or others). Not that also the Copyright in the License file has been updated, as well as the copyright in hundreds of files. No changes to the code has been performed: only changes to the copyright notices. The changes have been performed using "Replace in files" in IDEA.
