### PR TITLE
Follow up on migration from ANTLR 4 to ANTLR 5 on code and infrastructure level

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -95,10 +95,7 @@ jobs:
         env
 
         cd runtime-testsuite
-        case ${{ matrix.target }} in
-          python3) mvn -X '-Dantlr-python3-exec=${{ env.pythonLocation }}/bin/python' '-Dtest=python3.**' test ;;
-          *) mvn -X '-Dtest=${{ matrix.target }}.**' test ;;
-        esac
+        mvn -X '-Dtest=${{ matrix.target }}.**' test
 
     - name: Prepare artifacts
       if: always()

--- a/antlr5-maven-plugin/src/test/java/org/antlr/mojo/antlr5/Antlr5MojoTest.java
+++ b/antlr5-maven-plugin/src/test/java/org/antlr/mojo/antlr5/Antlr5MojoTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
-public class Antlr4MojoTest {
+public class Antlr5MojoTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,14 +129,6 @@
 				<artifactId>maven-clean-plugin</artifactId>
 				<version>3.1.0</version>
 				<configuration>
-					<filesets>
-						<fileset>
-							<directory>runtime/Swift/.build</directory>
-						</fileset>
-						<fileset>
-							<directory>runtime/Swift/Tests/Antlr4Tests/gen</directory>
-						</fileset>
-					</filesets>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

This combines three very small changes connected to the migration to ANTLR 5:
- Fix #21: Remove reference to Python in GitHub Actions workflow
- Fix #22: Rename Antlr4MojoTest in Antlr5TMojoTest
- Remove reference to Swift target in the clean task

This PR has been extracted from #23  